### PR TITLE
Add option to pass environment variables to AWS tools

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -6,6 +6,8 @@ var exec = require('child_process').exec
   , util = require('util')
   , http = require('http')
   , events = require("events")
+  , path = require("path")
+  , aws_env
 
 var tools = {}, apis = [
     'ec2',
@@ -15,10 +17,12 @@ var tools = {}, apis = [
     'aws_elb'
 ];
 
-exports.init = function(api, callback) {
+exports.init = function(api, env, callback) {
     var apis_comparison = '|' + apis.join('|') + '|',
         event = new events.EventEmitter(),
         completed = {};
+
+    aws_env = env || {}
 
     if (typeof api === "string") {
         api = [api];
@@ -79,9 +83,23 @@ createService = function(api, name) {
 
         if (api === 'ec2') args.options.push('--region ' + region);
 
-        exec(process.env[api.toUpperCase() + '_HOME'] + '/bin' + '/' + name + ' ' + args.options.join(' '), function(err, stdout, stderr) {
+        var env = ""
+        if (aws_env) {
+          env = Object.keys(aws_env).map(function(key) {
+            return key + "=" + '"' + aws_env[key] + '"'
+          }).join(" ")
+        }
+
+        var cmd = [
+          env,
+          path.join(process.env[api.toUpperCase() + '_HOME'], '/bin', name),
+          args.options.join(' '),
+        ].join(" ")
+
+        exec(cmd, function(err, stdout, stderr) {
             if (err !== null) {
                 console.log('exec error: ' + err);
+                console.log('exec cmd: ' + cmd)
             } else {
                 if (typeof args.callback !== 'undefined') {
                     args.callback(stdout);


### PR DESCRIPTION
init takes a environment option object as 2nd
parameter like
{ EC2_ACCESS_KEY: "MY_EC2_ACCESS_KEY" } which sets
environment variables for every AWS tool
invocation.
