### PR TITLE
Update git repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Timo Derstappen <teemow@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/teemow/node-aws.git"
+    "url": "https://github.com/adcloud/node-aws.git"
   },
   "main": "./lib/aws",
   "dependencies": {


### PR DESCRIPTION
It would be lovely if you could republish as well, so that the `npm docs aws` goes to the right place.
